### PR TITLE
feat(routing): explicit input picker + base filename routing to fixed job_dir; remove latest aliases

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -31,3 +31,16 @@ outputs:
   out_dir: "out"
   logs_dir: "out/logs"
   tmp_dir: "tmp"
+
+routes:
+  input:
+    domain_dir: "domain"
+    wordpress_dir: "wordpress"
+    subs_fallbacks: ["subs.txt","output/subs.txt","out/subs.txt"]
+  output:
+    job_dir: "out/jobs/current"
+naming:
+  suggest_timestamp: true
+persist:
+  remember_last: true
+  file: "config/last_routes.json"

--- a/panel.py
+++ b/panel.py
@@ -1,85 +1,203 @@
 #!/usr/bin/env python3
-import sys, os
+import os, sys, json
 from pathlib import Path
+from datetime import datetime
+from runners.common import ROOT, cfg, ensure_dirs, sanitize_base, timestamp, read_lines
 
-ROOT = Path(__file__).resolve().parent
+CONFIG = cfg()
+ROUTES = CONFIG["routes"]
+JOB_DIR = ROOT / ROUTES["output"]["job_dir"]
+PERSIST = CONFIG.get("persist", {})
+LAST_FILE = ROOT / PERSIST.get("file", "")
+
+
+def load_last():
+    if PERSIST.get("remember_last") and LAST_FILE.exists():
+        try:
+            return json.loads(LAST_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def save_last(data):
+    if not PERSIST.get("remember_last"):
+        return
+    LAST_FILE.parent.mkdir(parents=True, exist_ok=True)
+    LAST_FILE.write_text(json.dumps(data, indent=2))
+
+
+LAST = load_last()
+
+
+def choose_file(options, default_path=None):
+    uniq = []
+    seen = set()
+    for p in options:
+        if p not in seen:
+            uniq.append(p)
+            seen.add(p)
+    for idx, p in enumerate(uniq, 1):
+        print(f"  [{idx}] {p}")
+    while True:
+        prompt = "Select file"
+        if default_path:
+            prompt += f" [{default_path}]"
+        prompt += ": "
+        val = input(prompt).strip()
+        if not val and default_path:
+            p = Path(default_path)
+            if p.exists():
+                return p
+        if val.isdigit() and 1 <= int(val) <= len(uniq):
+            return uniq[int(val) - 1]
+        p = Path(val)
+        if p.exists():
+            return p
+        print("[!] Invalid selection.")
+
+
+def prompt_base(input_file: Path, task_key: str, mapping_func):
+    last_base = LAST.get(task_key, {}).get("base")
+    if last_base:
+        default = last_base
+    else:
+        base = sanitize_base(input_file.stem)
+        if CONFIG.get("naming", {}).get("suggest_timestamp", False):
+            base = f"{base}_{timestamp()}"
+        default = base
+    while True:
+        val = input(f"Base name [{default}]: ").strip() or default
+        val = sanitize_base(val)
+        paths = mapping_func(val)
+        print("Will create:")
+        for p in paths:
+            print(f"  - {p}")
+        if input("Proceed? [y/N]: ").strip().lower() == "y":
+            return val
+
+
+def task_sort_wp():
+    from runners.sort_wp import sort_wordpress
+    domain_dir = ROOT / ROUTES["input"]["domain_dir"]
+    files = sorted(domain_dir.glob("*.txt"))
+    default = LAST.get("sort_wp", {}).get("input")
+    f = choose_file(files, default)
+    base = prompt_base(f, "sort_wp", lambda b: [JOB_DIR / f"{b}.cms_wordpress.txt"])
+    out_file = sort_wordpress(f, JOB_DIR, base)
+    count = len(read_lines(out_file))
+    print(f"\n[OK] WordPress targets: {count}\n -> {out_file}")
+    LAST["sort_wp"] = {"input": str(f), "base": base}
+    save_last(LAST)
+    input("\nEnter to menu...")
+
+
+def task_httpx_live():
+    from runners.httpx_live import run_httpx_live
+    domain_dir = ROOT / ROUTES["input"]["domain_dir"]
+    files = sorted(domain_dir.glob("*.txt"))
+    default = LAST.get("httpx_live", {}).get("input")
+    f = choose_file(files, default)
+    base = prompt_base(
+        f,
+        "httpx_live",
+        lambda b: [JOB_DIR / f"{b}.live.txt", JOB_DIR / f"{b}.httpx.jsonl"],
+    )
+    live_file, jsonl, count = run_httpx_live(f, JOB_DIR, base)
+    print(f"\n[OK] Live endpoints: {count}\n -> {live_file}\n -> JSON: {jsonl}")
+    LAST["httpx_live"] = {"input": str(f), "base": base}
+    save_last(LAST)
+    input("\nEnter to menu...")
+
+
+def task_wpscan():
+    from runners.wpscan_fast import wpscan_fast
+    job_files = list(JOB_DIR.glob("*.txt"))
+    wp_dir = ROOT / ROUTES["input"]["wordpress_dir"]
+    files = job_files + list(wp_dir.glob("*.txt")) + list(wp_dir.glob("*.csv"))
+    default = LAST.get("wpscan", {}).get("input")
+    f = choose_file(files, default)
+    base = prompt_base(
+        f,
+        "wpscan",
+        lambda b: [JOB_DIR / "wpscan_raw" / f"{b}.<host>.wpscan.json"],
+    )
+    run_raw_dir = wpscan_fast(f, JOB_DIR, base)
+    print(
+        f"\n[OK] WPScan finished. Raw JSON -> {run_raw_dir}\n Log -> {CONFIG['outputs']['logs_dir']}/wp_scan.log"
+    )
+    LAST["wpscan"] = {"input": str(f), "base": base}
+    save_last(LAST)
+    input("\nEnter to menu...")
+
+
+def task_recon():
+    from runners.recon_nuclei import recon_pipeline
+    default = LAST.get("recon", {}).get("input")
+    subs = None
+    if default:
+        subs = Path(default)
+    else:
+        for rel in ROUTES["input"]["subs_fallbacks"]:
+            p = ROOT / rel
+            if p.exists():
+                subs = p
+                break
+    while True:
+        prompt = f"Subs file [{subs}]: " if subs else "Subs file: "
+        val = input(prompt).strip()
+        if not val:
+            if subs and subs.exists():
+                f = subs
+                break
+        else:
+            p = Path(val)
+            if p.exists():
+                f = p
+                break
+        print("[!] Invalid path.")
+    base = prompt_base(
+        f,
+        "recon",
+        lambda b: [
+            JOB_DIR / f"{b}.nuclei-findings.jsonl",
+            JOB_DIR / f"{b}.nuclei-findings.txt",
+            JOB_DIR / f"{b}.summary.txt",
+            JOB_DIR / f"{b}.wp-live.txt",
+            JOB_DIR / f"{b}.nuclei-findings-wp.jsonl",
+            JOB_DIR / f"{b}.nuclei-findings-wp.txt",
+            JOB_DIR / f"{b}.summary-wp.txt",
+        ],
+    )
+    paths = recon_pipeline(f, JOB_DIR, base)
+    print(f"\n[OK] Recon completed.\n -> {paths['findings_jsonl']}\n -> {paths['findings_txt']}\n -> {paths['summary']}")
+    LAST["recon"] = {"input": str(f), "base": base}
+    save_last(LAST)
+    input("\nEnter to menu...")
+
 
 def main():
     ensure_dirs()
     while True:
         os.system("cls" if os.name == "nt" else "clear")
         print("===== Recon & Vulnerability Panel (Python) =====")
-        print("  [1] Sort Domain \u2192 CMS (WordPress)")
+        print("  [1] Sort Domain → CMS (WordPress)")
         print("  [2] Live Domain Test (httpx)")
         print("  [3] WPScan (fast, JSON)")
         print("  [4] Recon Takeover/Upload (nuclei, sharded)")
         print("  [X] Exit")
         ch = input("\nSelect option: ").strip().lower()
-        if ch == "1": task_sort_wp()
-        elif ch == "2": task_httpx_live()
-        elif ch == "3": task_wpscan()
-        elif ch == "4": task_recon()
-        elif ch == "x": sys.exit(0)
+        if ch == "1":
+            task_sort_wp()
+        elif ch == "2":
+            task_httpx_live()
+        elif ch == "3":
+            task_wpscan()
+        elif ch == "4":
+            task_recon()
+        elif ch == "x":
+            sys.exit(0)
 
-def ensure_dirs():
-    for p in [
-        ROOT/"out","out/cms","out/live","out/wpscan/raw",
-        "out/nuclei-project","out/logs","tmp","domain","wordpress"
-    ]:
-        Path(p).mkdir(parents=True, exist_ok=True)
-
-def pick_file(dirpath: Path, exts=(".txt",)):
-    items = [p for p in dirpath.glob("*") if p.suffix.lower() in exts]
-    if not items:
-        print(f"[!] No input files under {dirpath}")
-        input("Enter to return...")
-        return None
-    print(f"\nAvailable in {dirpath}:")
-    for i,p in enumerate(items,1):
-        print(f"  [{i}] {p.name}")
-    try:
-        idx = int(input("Pick number: ").strip())
-        return items[idx-1]
-    except Exception:
-        print("[!] Invalid selection.")
-        input("Enter to return...")
-        return None
-
-def task_sort_wp():
-    from runners.sort_wp import sort_wordpress
-    f = pick_file(ROOT/"domain", (".txt",))
-    if not f: return
-    out_file, alias, count = sort_wordpress(input_file=f)
-    print(f"\n[OK] WordPress targets: {count}\n -> {out_file}\n -> alias: {alias}")
-    input("\nEnter to menu...")
-
-def task_httpx_live():
-    from runners.httpx_live import run_httpx_live
-    f = pick_file(ROOT/"domain", (".txt",))
-    if not f: return
-    live_file, jsonl, count = run_httpx_live(input_file=f)
-    print(f"\n[OK] Live endpoints: {count}\n -> {live_file}\n -> JSON: {jsonl}")
-    input("\nEnter to menu...")
-
-def task_wpscan():
-    from runners.wpscan_fast import wpscan_fast
-    src = ROOT/"out/cms/wordpress.txt"
-    if not src.exists():
-        alt = pick_file(ROOT/"wordpress", (".txt",".csv"))
-        if not alt: return
-        src = alt
-    wpscan_fast(source_file=src)
-    print("\n[OK] WPScan finished. Raw JSON -> out/wpscan/raw/ ; Log -> out/logs/wp_scan.log")
-    input("\nEnter to menu...")
-
-def task_recon():
-    from runners.recon_nuclei import recon_pipeline
-    recon_pipeline()
-    print("\n[OK] Recon completed.")
-    print(" -> out\\nuclei-findings.jsonl")
-    print(" -> out\\nuclei-findings.txt")
-    print(" -> out\\summary.txt")
-    input("\nEnter to menu...")
 
 if __name__ == "__main__":
     main()

--- a/runners/common.py
+++ b/runners/common.py
@@ -53,6 +53,18 @@ def cfg():
                   "exclude_tags":["code"],"severity":["critical","high"]},
         "wp":{"wpscan_max_threads":10,"request_timeout":12,"connect_timeout":5,"tls_disable_checks":True},
         "outputs":{"out_dir":"out","logs_dir":"out/logs","tmp_dir":"tmp"},
+        "routes":{
+            "input":{
+                "domain_dir":"domain",
+                "wordpress_dir":"wordpress",
+                "subs_fallbacks":["subs.txt","output/subs.txt","out/subs.txt"]
+            },
+            "output":{
+                "job_dir":"out/jobs/current"
+            }
+        },
+        "naming":{"suggest_timestamp":True},
+        "persist":{"remember_last":True,"file":"config/last_routes.json"},
     }
 
 def timestamp():
@@ -60,12 +72,21 @@ def timestamp():
 
 def ensure_dirs():
     c = cfg()
-    for p in ["out_dir","logs_dir","tmp_dir"]:
-        Path(ROOT / c["outputs"][p]).mkdir(parents=True, exist_ok=True)
-    (ROOT/"out"/"cms").mkdir(parents=True, exist_ok=True)
-    (ROOT/"out"/"live").mkdir(parents=True, exist_ok=True)
-    (ROOT/"out"/"wpscan"/"raw").mkdir(parents=True, exist_ok=True)
-    (ROOT/"out"/"nuclei-project").mkdir(parents=True, exist_ok=True)
+    paths = [
+        ROOT / c["outputs"]["out_dir"],
+        ROOT / c["outputs"]["logs_dir"],
+        ROOT / c["outputs"]["tmp_dir"],
+        ROOT / c["routes"]["input"]["domain_dir"],
+        ROOT / c["routes"]["input"]["wordpress_dir"],
+        ROOT / c["routes"]["output"]["job_dir"],
+        ROOT / "out" / "nuclei-project",
+    ]
+    for p in paths:
+        Path(p).mkdir(parents=True, exist_ok=True)
+
+def sanitize_base(name: str) -> str:
+    name = name.replace(" ", "_")
+    return re.sub(r"[^A-Za-z0-9._-]", "_", name)
 
 def exe_name(base):
     return base + ".exe" if os.name == "nt" else base

--- a/runners/httpx_live.py
+++ b/runners/httpx_live.py
@@ -1,27 +1,31 @@
-﻿from pathlib import Path
-from .common import ROOT, cfg, bin_path, timestamp, write_lines, alias_copy, run_cmd, read_lines
+from pathlib import Path
+from .common import ROOT, cfg, bin_path, run_cmd, read_lines
 
-def run_httpx_live(input_file: Path):
+
+def run_httpx_live(input_file: Path, job_dir: Path, base: str):
     c = cfg()
     httpx = bin_path("httpx")
-    ts = timestamp()
-    out_dir = ROOT / c["outputs"]["out_dir"]
-    live_one = out_dir / "live" / f"{ts}.txt"
-    httpx_jsonl = out_dir / "httpx.jsonl"
+    live_one = job_dir / f"{base}.live.txt"
+    httpx_jsonl = job_dir / f"{base}.httpx.jsonl"
 
     args_base = [
-        httpx, "-l", str(input_file), "-silent",
-        "-follow-redirects", "-threads", str(c["httpx"]["threads"]),
-        "-timeout", str(c["httpx"]["timeout"]), "-retries", str(c["httpx"]["retries"]),
-        "-mc", ",".join(str(x) for x in c["httpx"]["mc"])
+        httpx,
+        "-l",
+        str(input_file),
+        "-silent",
+        "-follow-redirects",
+        "-threads",
+        str(c["httpx"]["threads"]),
+        "-timeout",
+        str(c["httpx"]["timeout"]),
+        "-retries",
+        str(c["httpx"]["retries"]),
+        "-mc",
+        ",".join(str(x) for x in c["httpx"]["mc"]),
     ]
-    # plain list
     run_cmd(args_base, stdout_file=str(live_one), append=False)
-    # jsonl alias
     args_json = args_base + ["-json", "-o", str(httpx_jsonl)]
     run_cmd(args_json)
 
-    # alias: out/live.txt
-    alias_copy(live_one, out_dir / "live.txt")
     lines = read_lines(live_one)
     return live_one, httpx_jsonl, len(lines)

--- a/runners/recon_nuclei.py
+++ b/runners/recon_nuclei.py
@@ -1,31 +1,22 @@
-﻿import subprocess, threading
+import subprocess, threading
 from pathlib import Path
-from .common import ROOT, cfg, bin_path, timestamp, write_lines, read_lines, alias_copy, parse_nuclei_jsonl, SEV_ORDER, ensure_dirs
+from .common import ROOT, cfg, bin_path, timestamp, write_lines, read_lines, parse_nuclei_jsonl, SEV_ORDER, ensure_dirs
 
-def recon_pipeline():
+
+def recon_pipeline(input_subs: Path, job_dir: Path, base: str):
     ensure_dirs()
     c = cfg()
-    out_dir = ROOT / c["outputs"]["out_dir"]
     tmp_dir = ROOT / c["outputs"]["tmp_dir"]
     logs_dir = ROOT / c["outputs"]["logs_dir"]
-    tmp_dir.mkdir(parents=True, exist_ok=True); logs_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
 
-    # 1) Input subs
-    subs = ROOT/"subs.txt"
-    if not subs.exists():
-        for alt in [ROOT/"output/subs.txt", out_dir/"subs.txt"]:
-            if alt.exists(): subs = alt; break
-    if not subs.exists():
-        raise SystemExit("[!] subs.txt not found in repo root/output/out")
-
-    # 2) httpx live (also jsonl)
     from .httpx_live import run_httpx_live
-    live_file, httpx_jsonl, live_count = run_httpx_live(subs)
+    live_file, httpx_jsonl, live_count = run_httpx_live(input_subs, job_dir, base)
 
-    # 3) shard
     shards = int(c["nuclei"]["shards"])
     live = read_lines(live_file)
-    shard_paths=[]
+    shard_paths = []
     for i in range(shards):
         p = tmp_dir / f"{timestamp()}_shard_{i}.txt"
         shard_paths.append(p)
@@ -33,51 +24,75 @@ def recon_pipeline():
     for idx, u in enumerate(live):
         sp = shard_paths[idx % shards]
         with sp.open("a", encoding="utf-8") as fh:
-            fh.write(u+"\n")
+            fh.write(u + "\n")
 
-    # 4) nuclei per shard (parallel)
-    threads=[]
+    threads = []
     for i, sp in enumerate(shard_paths):
         outj = tmp_dir / f"nuclei_shard_{i}.jsonl"
         t = threading.Thread(target=_nuclei_one, args=(sp, outj))
         t.start()
-        threads.append((t,outj))
-    for t,_ in threads: t.join()
+        threads.append((t, outj))
+    for t, _ in threads:
+        t.join()
 
-    # 5) merge + human summary
-    merged = out_dir / "nuclei-findings.jsonl"
+    merged = job_dir / f"{base}.nuclei-findings.jsonl"
     with merged.open("w", encoding="utf-8") as outfh:
-        for _,outj in threads:
+        for _, outj in threads:
             if outj.exists():
                 outfh.write(outj.read_text(encoding="utf-8", errors="ignore"))
-    human = out_dir / "nuclei-findings.txt"
-    summary = out_dir / "summary.txt"
+    human = job_dir / f"{base}.nuclei-findings.txt"
+    summary = job_dir / f"{base}.summary.txt"
     _make_summaries(merged, human, summary)
 
-    # 6) WordPress focus
-    wp_live = out_dir / "wp-live.txt"
+    wp_live = job_dir / f"{base}.wp-live.txt"
     _derive_wp_live(live_file, wp_live)
-    if wp_live.exists() and wp_live.stat().st_size>0:
-        _nuclei_wp(wp_live, out_dir)
+    wp_paths = {}
+    if wp_live.exists() and wp_live.stat().st_size > 0:
+        wp_paths = _nuclei_wp(wp_live, job_dir, base)
+
+    return {
+        "live": live_file,
+        "httpx_jsonl": httpx_jsonl,
+        "findings_jsonl": merged,
+        "findings_txt": human,
+        "summary": summary,
+        **wp_paths,
+    }
+
 
 def _nuclei_one(shard_file: Path, out_jsonl: Path):
     c = cfg()
     nuclei = bin_path("nuclei")
-    config_yaml = str((ROOT/"nuclei-config-takeover.yaml").resolve())
-    prj = (ROOT/"out"/"nuclei-project").resolve()
+    config_yaml = str((ROOT / "nuclei-config-takeover.yaml").resolve())
+    prj = (ROOT / "out" / "nuclei-project").resolve()
     args = [
-        nuclei, "-l", str(shard_file),
-        "-config", config_yaml,
-        "-severity", ",".join(c["nuclei"]["severity"]),
-        "-exclude-tags", ",".join(c["nuclei"]["exclude_tags"]),
-        "-c", str(c["nuclei"]["concurrency"]),
-        "-rl", str(c["nuclei"]["rate_limit"]),
-        "-timeout", str(c["nuclei"]["timeout"]),
-        "-retries", str(c["nuclei"]["retries"]),
-        "-bulk-size", str(c["nuclei"]["bulk_size"]),
-        "-project", "-project-path", str(prj),
-        "-jsonl", "-o", str(out_jsonl),
-        "-silent","-stats"
+        nuclei,
+        "-l",
+        str(shard_file),
+        "-config",
+        config_yaml,
+        "-severity",
+        ",".join(c["nuclei"]["severity"]),
+        "-exclude-tags",
+        ",".join(c["nuclei"]["exclude_tags"]),
+        "-c",
+        str(c["nuclei"]["concurrency"]),
+        "-rl",
+        str(c["nuclei"]["rate_limit"]),
+        "-timeout",
+        str(c["nuclei"]["timeout"]),
+        "-retries",
+        str(c["nuclei"]["retries"]),
+        "-bulk-size",
+        str(c["nuclei"]["bulk_size"]),
+        "-project",
+        "-project-path",
+        str(prj),
+        "-jsonl",
+        "-o",
+        str(out_jsonl),
+        "-silent",
+        "-stats",
     ]
     tags = list(c["nuclei"]["tags_base"])
     if c["nuclei"]["enable_extra_tags"]:
@@ -87,63 +102,87 @@ def _nuclei_one(shard_file: Path, out_jsonl: Path):
         args += ["-ni"]
     subprocess.call(args)
 
+
 def _derive_wp_live(live_file: Path, wp_out: Path):
     from .common import cfg, bin_path, read_lines, write_lines
+
     c = cfg()
     httpx = bin_path("httpx")
     args = [
-        httpx, "-l", str(live_file), "-silent", "-follow-redirects",
-        "-threads", str(c["httpx"]["threads"]), "-timeout", str(c["httpx"]["timeout"]),
-        "-mc", ",".join(str(x) for x in c["httpx"]["mc"]), "-path", "/wp-login.php"
+        httpx,
+        "-l",
+        str(live_file),
+        "-silent",
+        "-follow-redirects",
+        "-threads",
+        str(c["httpx"]["threads"]),
+        "-timeout",
+        str(c["httpx"]["timeout"]),
+        "-mc",
+        ",".join(str(x) for x in c["httpx"]["mc"]),
+        "-path",
+        "/wp-login.php",
     ]
-    import subprocess, tempfile
+    import tempfile
+
     tmp = Path(tempfile.mkstemp(prefix="wplive_")[1])
-    with open(tmp,"wb") as fh:
+    with open(tmp, "wb") as fh:
         subprocess.call(args, stdout=fh, stderr=subprocess.STDOUT)
-    lines=[]
+    lines = []
     for h in read_lines(tmp):
         lines.append(h.split("/wp-login.php")[0])
     write_lines(wp_out, sorted(set(lines)))
-    try: tmp.unlink(missing_ok=True)
-    except: pass
+    try:
+        tmp.unlink(missing_ok=True)
+    except:
+        pass
 
-def _nuclei_wp(wp_list: Path, out_dir: Path):
-    tmp_out = out_dir / "nuclei-findings-wp.jsonl"
+
+def _nuclei_wp(wp_list: Path, job_dir: Path, base: str):
+    tmp_out = job_dir / f"{base}.nuclei-findings-wp.jsonl"
     _nuclei_one(wp_list, tmp_out)
-    human = out_dir / "nuclei-findings-wp.txt"
-    summary = out_dir / "summary-wp.txt"
+    human = job_dir / f"{base}.nuclei-findings-wp.txt"
+    summary = job_dir / f"{base}.summary-wp.txt"
     _make_summaries(tmp_out, human, summary)
+    return {
+        "wp_live": wp_list,
+        "wp_jsonl": tmp_out,
+        "wp_txt": human,
+        "wp_summary": summary,
+    }
+
 
 def _make_summaries(jsonl_path: Path, human_txt: Path, summary_txt: Path):
-    if not jsonl_path.exists() or jsonl_path.stat().st_size==0:
+    if not jsonl_path.exists() or jsonl_path.stat().st_size == 0:
         human_txt.write_text("", encoding="utf-8")
         summary_txt.write_text("No findings.\n", encoding="utf-8")
         return
-    findings=[]
-    counts={}
+    findings = []
+    counts = {}
     for obj in parse_nuclei_jsonl(jsonl_path):
         info = obj.get("info") or {}
         sev = (info.get("severity") or "unknown").lower()
-        tid = obj.get("template-id","")
+        tid = obj.get("template-id", "")
         host = obj.get("host") or obj.get("matched-at") or obj.get("matched") or ""
         findings.append((sev, tid, host))
-        counts[sev]=counts.get(sev,0)+1
+        counts[sev] = counts.get(sev, 0) + 1
 
-    # human list (sorted by severity -> template -> host)
-    lines=[]
-    for sev,tid,host in sorted(findings, key=lambda x:(SEV_ORDER.get(x[0],9), x[1], x[2]))[:1000]:
+    lines = []
+    for sev, tid, host in sorted(findings, key=lambda x: (SEV_ORDER.get(x[0], 9), x[1], x[2]))[:1000]:
         lines.append(f"[{sev.upper():8}] {tid:40} {host}")
-    human_txt.write_text("\n".join(lines)+"\n", encoding="utf-8")
+    human_txt.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-    # summary totals + top 30 sev|template
     from collections import Counter
-    pair = Counter((sev,tid) for sev,tid,_ in findings)
+
+    pair = Counter((sev, tid) for sev, tid, _ in findings)
     top = pair.most_common(30)
-    s=[]
+    s = []
     s.append("Totals:")
-    for k in ["critical","high","medium","low","info"]:
-        if k in counts: s.append(f"  {k}: {counts[k]}")
+    for k in ["critical", "high", "medium", "low", "info"]:
+        if k in counts:
+            s.append(f"  {k}: {counts[k]}")
     s.append("\nTop 30 (severity|template-id|count):")
-    for (sev,tid),cnt in top:
+    for (sev, tid), cnt in top:
         s.append(f"  {sev}|{tid}|{cnt}")
-    summary_txt.write_text("\n".join(s)+"\n", encoding="utf-8")
+    summary_txt.write_text("\n".join(s) + "\n", encoding="utf-8")
+

--- a/runners/sort_wp.py
+++ b/runners/sort_wp.py
@@ -1,53 +1,55 @@
-﻿import subprocess
+import subprocess
 from pathlib import Path
-from .common import ROOT, cfg, bin_path, timestamp, write_lines, alias_copy, read_lines
+from .common import ROOT, cfg, bin_path, write_lines, read_lines
 
-def sort_wordpress(input_file: Path):
+
+def sort_wordpress(input_file: Path, job_dir: Path, base: str):
     c = cfg()
     httpx = bin_path("httpx")
-    ts = timestamp()
-    out_dir = ROOT / c["outputs"]["out_dir"]
     tmp_dir = ROOT / c["outputs"]["tmp_dir"]
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
-    # normalize to https://
     raw = read_lines(input_file)
     norm = []
     for s in raw:
         s = s.strip()
-        if not s: continue
-        if "://" not in s: s = "https://" + s
+        if not s:
+            continue
+        if "://" not in s:
+            s = "https://" + s
         norm.append(s)
-    norm_file = tmp_dir / f"norm_{ts}.txt"
+    norm_file = tmp_dir / f"norm_{base}.txt"
     write_lines(norm_file, norm)
 
-    # detect via /wp-login.php and /wp-json/
-    hits_file = tmp_dir / f"wp_hits_{ts}.txt"
+    hits_file = tmp_dir / f"wp_hits_{base}.txt"
     args_common = [
-        httpx, "-l", str(norm_file), "-silent", "-follow-redirects",
-        "-threads", str(c["httpx"]["threads"]), "-timeout", str(c["httpx"]["timeout"]),
-        "-mc", ",".join(str(x) for x in c["httpx"]["mc"])
+        httpx,
+        "-l",
+        str(norm_file),
+        "-silent",
+        "-follow-redirects",
+        "-threads",
+        str(c["httpx"]["threads"]),
+        "-timeout",
+        str(c["httpx"]["timeout"]),
+        "-mc",
+        ",".join(str(x) for x in c["httpx"]["mc"]),
     ]
-    # /wp-login.php
     args1 = args_common + ["-path", "/wp-login.php"]
     with open(hits_file, "ab") as fh:
         subprocess.call(args1, stdout=fh, stderr=subprocess.STDOUT)
-    # /wp-json/
     args2 = args_common + ["-path", "/wp-json/"]
     with open(hits_file, "ab") as fh:
         subprocess.call(args2, stdout=fh, stderr=subprocess.STDOUT)
 
-    # dedup + strip paths
     hits = read_lines(hits_file)
-    base = []
+    base_urls = []
     seen = set()
     for h in hits:
         u = h.split("/wp-login.php")[0].split("/wp-json/")[0]
         if u not in seen:
             seen.add(u)
-            base.append(u)
-    outwp = out_dir / "cms" / f"{ts}_wordpress.txt"
-    write_lines(outwp, base)
-    alias = out_dir / "cms" / "wordpress.txt"
-    alias_copy(outwp, alias)
-    return outwp, alias, len(base)
+            base_urls.append(u)
+    out_file = job_dir / f"{base}.cms_wordpress.txt"
+    write_lines(out_file, base_urls)
+    return out_file

--- a/runners/wpscan_fast.py
+++ b/runners/wpscan_fast.py
@@ -1,81 +1,103 @@
-﻿import os, re, csv, tempfile, subprocess
+import os, re, csv, tempfile, subprocess
 from pathlib import Path
-from .common import ROOT, cfg, bin_path, timestamp, write_lines, read_lines, url_host
+from .common import ROOT, cfg, bin_path, write_lines, read_lines, url_host
+
 
 def _ensure_db(log_file: Path):
-    # first time update; fallback with TLS disable if needed
     with open(log_file, "ab") as fh:
-        rc = subprocess.call(["ruby","-S","wpscan","--update"], stdout=fh, stderr=subprocess.STDOUT)
+        rc = subprocess.call(["ruby", "-S", "wpscan", "--update"], stdout=fh, stderr=subprocess.STDOUT)
         if rc != 0:
-            subprocess.call(["ruby","-S","wpscan","--update","--disable-tls-checks"], stdout=fh, stderr=subprocess.STDOUT)
+            subprocess.call(["ruby", "-S", "wpscan", "--update", "--disable-tls-checks"], stdout=fh, stderr=subprocess.STDOUT)
+
 
 def _normalize_via_httpx(lines):
     httpx = bin_path("httpx")
     tmp_in = Path(tempfile.mkstemp(prefix="wps_")[1])
     write_lines(tmp_in, lines)
-    tmp_out = Path(str(tmp_in)+".live.txt")
-    subprocess.call([httpx,"-l",str(tmp_in),"-silent","-follow-redirects","-threads","60","-timeout","8"], stdout=open(tmp_out,"wb"))
+    tmp_out = Path(str(tmp_in) + ".live.txt")
+    subprocess.call(
+        [httpx, "-l", str(tmp_in), "-silent", "-follow-redirects", "-threads", "60", "-timeout", "8"],
+        stdout=open(tmp_out, "wb"),
+    )
     out_lines = read_lines(tmp_out)
     try:
         tmp_in.unlink(missing_ok=True)
         tmp_out.unlink(missing_ok=True)
-    except: pass
+    except:
+        pass
     return out_lines
 
+
 def _load_sources(source_file: Path):
-    if source_file.suffix.lower()==".csv":
-        import csv, re
-        urls=[]
-        for row in csv.reader(source_file.open("r",encoding="utf-8",errors="ignore")):
-            joined=",".join(row)
-            m=re.search(r"(https?://[^\s,;]+)", joined, re.I)
-            if m: urls.append(m.group(1))
+    if source_file.suffix.lower() == ".csv":
+        urls = []
+        for row in csv.reader(source_file.open("r", encoding="utf-8", errors="ignore")):
+            joined = ",".join(row)
+            m = re.search(r"(https?://[^\s,;]+)", joined, re.I)
+            if m:
+                urls.append(m.group(1))
         return urls
     else:
         return read_lines(source_file)
 
-def wpscan_fast(source_file: Path):
+
+def wpscan_fast(source_file: Path, job_dir: Path, base: str):
     c = cfg()
-    out_dir = ROOT / c["outputs"]["out_dir"]
+    raw_dir = job_dir / "wpscan_raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
     logs = ROOT / c["outputs"]["logs_dir"]
     logs.mkdir(parents=True, exist_ok=True)
     logf = logs / "wp_scan.log"
     _ensure_db(logf)
 
-    # load + normalize
     raw = _load_sources(source_file)
-    norm=[]
-    seen=set()
+    norm = []
+    seen = set()
     for s in raw:
-        s=s.strip()
-        if not s: continue
-        if "://" not in s: s="https://"+s
+        s = s.strip()
+        if not s:
+            continue
+        if "://" not in s:
+            s = "https://" + s
         if s not in seen:
-            seen.add(s); norm.append(s)
+            seen.add(s)
+            norm.append(s)
 
-    # verify via httpx
     norm = _normalize_via_httpx(norm)
 
-    ts = timestamp()
     for url in norm:
         host = url_host(url)
-        outj = out_dir / "wpscan" / "raw" / f"{ts}_{host}.json"
+        outj = raw_dir / f"{base}.{host}.wpscan.json"
         cmd = [
-            "ruby","-S","wpscan",
-            "--url", url,
-            "--no-update","--force","--random-user-agent"
+            "ruby",
+            "-S",
+            "wpscan",
+            "--url",
+            url,
+            "--no-update",
+            "--force",
+            "--random-user-agent",
         ]
         if c["wp"]["tls_disable_checks"]:
             cmd.append("--disable-tls-checks")
         cmd += [
-            "--plugins-detection","passive",
-            "--themes-detection","passive",
-            "--enumerate","vp,vt,tt,cb",
-            "--max-threads", str(c["wp"]["wpscan_max_threads"]),
-            "--request-timeout", str(c["wp"]["request_timeout"]),
-            "--connect-timeout", str(c["wp"]["connect_timeout"]),
-            "--format","json",
-            "--output", str(outj)
+            "--plugins-detection",
+            "passive",
+            "--themes-detection",
+            "passive",
+            "--enumerate",
+            "vp,vt,tt,cb",
+            "--max-threads",
+            str(c["wp"]["wpscan_max_threads"]),
+            "--request-timeout",
+            str(c["wp"]["request_timeout"]),
+            "--connect-timeout",
+            str(c["wp"]["connect_timeout"]),
+            "--format",
+            "json",
+            "--output",
+            str(outj),
         ]
-        with open(logf,"ab") as fh:
+        with open(logf, "ab") as fh:
             subprocess.call(cmd, stdout=fh, stderr=subprocess.STDOUT)
+    return raw_dir


### PR DESCRIPTION
## Summary
- add configurable input/output routes with base-name suggestions and persistence
- update dashboard to pick explicit input files and base names before each run
- route runner outputs into the fixed job directory with no latest aliases

## Testing
- `python -m py_compile panel.py runners/common.py runners/httpx_live.py runners/sort_wp.py runners/wpscan_fast.py runners/recon_nuclei.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab123c21e48331a1daaab07d2c7542